### PR TITLE
Change .json() to .text

### DIFF
--- a/autorequests/classes/method.py
+++ b/autorequests/classes/method.py
@@ -58,7 +58,7 @@ class Method:
                             "cookies": cookies}.items():
             if data:
                 body += f", {kwarg}=" + format_dict(data)
-        body += ").json()"
+        body += ").text"
         return self.signature + "\n" + indent(body, spaces=4)
 
     @property


### PR DESCRIPTION
Change `.json()` to `.text` because not all API's and website's return as json